### PR TITLE
Added {i} to preferences for input filename

### DIFF
--- a/bl/operators/run_external.py
+++ b/bl/operators/run_external.py
@@ -93,6 +93,10 @@ class SCENE_OT_bf_run_fds(Operator):
                 name=sc.name,
                 extension=".fds",
             )
+            fds_filename = utils.io.get_filename(
+                name=sc.name,
+                extension=".fds"
+            )
         except Exception as err:
             w.cursor_modal_restore()
             self.report({"ERROR"}, str(err))
@@ -118,6 +122,7 @@ class SCENE_OT_bf_run_fds(Operator):
             fds_command.replace("{n}", str(n))
             .replace("{t}", str(t))
             .replace("{f}", fds_filepath)
+            .replace("{i}", fds_filename)
             .replace("{p}", fds_path)
         )
         command = term_command.replace("{c}", fds_command)

--- a/bl/preferences.py
+++ b/bl/preferences.py
@@ -44,6 +44,7 @@ class BFPreferences(AddonPreferences):
                 " <{n}> is replaced by the number of MPI processes,",
                 " <{t}> by the number of threads,",
                 " <{f}> by the fds case filepath (eg. /example/case.fds).",
+                " <{i}> by the fds case inputfile (eg. case.fds).",
                 " <{p}> by the fds case path (eg. /example/).",
             )
         ),

--- a/utils/io.py
+++ b/utils/io.py
@@ -195,9 +195,11 @@ def transform_abs_to_rfds(filepath, sc) -> str:
 
 # Others
 
+def get_filename(name="", extension="") -> str:
+    return bpy.path.ensure_ext(name, extension)
 
 def append_filename(path="", name="", extension="") -> str:
-    filename = bpy.path.ensure_ext(name, extension)
+    filename = get_filename(name, extension)
     return os.path.join(path, filename)
 
 


### PR DESCRIPTION
Hi,

Thank you for this great Blender add-on!

Unfortunately, we had problems executing the "Run FDS" button, as there was no option in the settings to only pass the filename to FDS (e.g. `fds input.fds` instead of `fds C:\abc\def\input.fds`). There was only the variable {f}.

Therefore I added a variable {i} to the settings, which stands for the input filename.

This is not a breaking change. It is an extension. I would be very happy if you could merge these changes.

Many thanks and best regards!
Robert